### PR TITLE
feat: improve docker image to find Go library on the operating system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 
 RUN apk --no-cache add ca-certificates
-RUN CGO_ENABLED=0 go build -o /app ./cmd/api
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app ./cmd/api
 
 FROM scratch
 


### PR DESCRIPTION
## Summary
Improve the docker image to run Go library on the operating system.


```console
mongchelee@limengzhes-MacBook-Pro molpastream % docker build -t molpastream .
[+] Building 7.4s (10/14)                                                                                                                       
 => [internal] load build definition from Dockerfile                                                                                       0.0s
 => => transferring dockerfile: 525B                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                          0.0s
 => => transferring context: 2B                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/golang:1.18.3-alpine                                                                    3.0s
 => [builder 1/8] FROM docker.io/library/golang:1.18.3-alpine@sha256:7cc62574fcf9c5fb87ad42a9789d5539a6a085971d58ee75dd2ee146cb8a8695      0.0s
 => [internal] load build context                                                                                                          0.0s
 => => transferring context: 43.72kB                                                                                                       0.0s
 => CACHED [builder 2/8] WORKDIR /src                                                                                                      0.0s
 => CACHED [builder 3/8] COPY go.mod .                                                                                                     0.0s
 => CACHED [builder 4/8] COPY go.sum .                        [+] Building 7.5s (10/14)                                                                                                                       5/8] RUN go mod download                   => [internal] load build definition from Dockerfile                                                                                       0.0sOPY . .                                     => => transferring dockerfile: 525B                                                                                                       0.0sUN apk --no-cache add ca-certificates       => [internal] load .dockerignore                                                                                                          0.0ss://dl-cdn.alpinelinux.org/alpine/v3.16/mai => => transferring context: 2B                                                                                                            0.0ss://dl-cdn.alpinelinux.org/alpine/v3.16/com => [internal] load metadata for docker.io/library/golang:1.18.3-alpine                                                                    3.0s
 => [builder 1/8] FROM docker.io/library/golang:1.18.3-alpine@sha256:7cc62574fcf9c5fb87ad42a9789d5539a6a085971d58ee75dd2ee146cb8a8695      0.0s
 => [internal] load build context                                                                                                          0.0s
 => => transferring context: 43.72kB                                                                                                       0.0s
 => CACHED [builder 2/8] WORKDIR /src                                                                                                      0.0s
 => CACHED [builder 3/8] COPY go.mod .                                                                                                     0.0s
 => CACHED [builder 4/8] COPY go.sum .                        [+] Building 7.7s (10/14)                                                                                                                       5/8] RUN go mod download                   => [internal] load build definition from Dockerfile                                                                                       0.0sOPY . .                                     => => transferring dockerfile: 525B                                                                                                       0.0sUN apk --no-cache add ca-certificates       => [internal] load .dockerignore                                                                                                          0.0ss://dl-cdn.alpinelinux.org/alpine/v3.16/mai => => transferring context: 2B                                                                                                            0.0ss://dl-cdn.alpinelinux.org/alpine/v3.16/com => [internal] load metadata for docker.io/library/golang:1.18.3-alpine                                                                    3.0s
 => [builder 1/8] FROM docker.io/library/golang:1.18.3-alpine@sha256:7cc62574fcf9c5fb87ad42a9789d5539a6a085971d58ee75dd2ee146cb8a8695      0.0s
 => [internal] load build context                                                                                                          0.0s
 => => transferring context: 43.72kB                                                                                                       0.0s
 => CACHED [builder 2/8] WORKDIR /src                                                                                                      0.0s
 => CACHED [builder 3/8] COPY go.mod .                                                                                                     0.0s
 => CACHED [builder 4/8] COPY go.sum .                        [+] Building 27.1s (15/15) FINISHED                            => [internal] load build definition from Dockerfile     0.0s
 => => transferring dockerfile: 525B                     0.0s  => [internal] load .dockerignore                        0.0s  => => transferring context: 2B                          0.0s
 => [internal] load metadata for docker.io/library/gola  3.0s  => [builder 1/8] FROM docker.io/library/golang:1.18.3-  0.0s  => [internal] load build context                        0.0s
 => => transferring context: 43.72kB                     0.0s  => CACHED [builder 2/8] WORKDIR /src                    0.0s  => CACHED [builder 3/8] COPY go.mod .                   0.0s
 => CACHED [builder 4/8] COPY go.sum .                   0.0si => CACHED [builder 5/8] RUN go mod download             0.0s  => [builder 6/8] COPY . .                               0.1s
 => [builder 7/8] RUN apk --no-cache add ca-certificate  5.3sm => [builder 8/8] RUN CGO_ENABLED=0 GOOS=linux go buil  17.5s  => CACHED [stage-1 1/2] COPY --from=builder /app /app   0.0s 
 => CACHED [stage-1 2/2] COPY --from=builder /etc/ssl/c  0.0s
 => exporting to image                                   0.0s
 => => exporting layers                                  0.0s
 => => writing image sha256:e9c62c94e30c1c4a126551ce1c3  0.0s
 => => naming to docker.io/library/molpastream           0.0s
mongchelee@limengzhes-MacBook-Pro molpastream % 
```