### PR TITLE
feat: transcode the uploaded video file to HLS format

### DIFF
--- a/aws/lambda/README.md
+++ b/aws/lambda/README.md
@@ -1,0 +1,10 @@
+## AWS Lambda function
+
+Build AWS lambda functions to trigger event processing.
+
+### Getting started
+```console
+# Note the output executable name is in correspondence with lambda function handler.
+$ GOOS=linux GOARCH=amd64 go build -o main main.go
+$ zip lambda.zip main
+```

--- a/aws/lambda/batch_transcode/.gitignore
+++ b/aws/lambda/batch_transcode/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!*.go
+!*.json

--- a/aws/lambda/batch_transcode/job.json
+++ b/aws/lambda/batch_transcode/job.json
@@ -1,0 +1,342 @@
+{
+  "OutputGroups": [
+    {
+      "CustomName": "HLS",
+      "Name": "Apple HLS",
+      "Outputs": [
+        {
+          "ContainerSettings": {
+            "Container": "M3U8",
+            "M3u8Settings": {
+              "AudioFramesPerPes": 4,
+              "PcrControl": "PCR_EVERY_PES_PACKET",
+              "PmtPid": 480,
+              "PrivateMetadataPid": 503,
+              "ProgramNumber": 1,
+              "PatInterval": 0,
+              "PmtInterval": 0,
+              "TimedMetadata": "NONE",
+              "VideoPid": 481,
+              "AudioPids": [
+                  482,
+                  483,
+                  484,
+                  485,
+                  486,
+                  487,
+                  488,
+                  489,
+                  490,
+                  491,
+                  492
+              ]
+            }
+          },
+          "VideoDescription": {
+            "Width": 640,
+            "ScalingBehavior": "DEFAULT",
+            "Height": 360,
+            "TimecodeInsertion": "DISABLED",
+            "AntiAlias": "ENABLED",
+            "Sharpness": 50,
+            "CodecSettings": {
+              "Codec": "H_264",
+              "H264Settings": {
+                "InterlaceMode": "PROGRESSIVE",
+                "NumberReferenceFrames": 3,
+                "Syntax": "DEFAULT",
+                "Softness": 0,
+                "GopClosedCadence": 1,
+                "GopSize": 2,
+                "Slices": 1,
+                "GopBReference": "DISABLED",
+                "MaxBitrate": 1200000,
+                "SlowPal": "DISABLED",
+                "SpatialAdaptiveQuantization": "ENABLED",
+                "TemporalAdaptiveQuantization": "ENABLED",
+                "FlickerAdaptiveQuantization": "DISABLED",
+                "EntropyEncoding": "CABAC",
+                "FramerateControl": "INITIALIZE_FROM_SOURCE",
+                "RateControlMode": "QVBR",
+                "CodecProfile": "MAIN",
+                "Telecine": "NONE",
+                "MinIInterval": 0,
+                "AdaptiveQuantization": "HIGH",
+                "CodecLevel": "AUTO",
+                "FieldEncoding": "PAFF",
+                "SceneChangeDetect": "TRANSITION_DETECTION",
+                "QualityTuningLevel": "SINGLE_PASS_HQ",
+                "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+                "UnregisteredSeiTimecode": "DISABLED",
+                "GopSizeUnits": "SECONDS",
+                "ParControl": "INITIALIZE_FROM_SOURCE",
+                "NumberBFramesBetweenReferenceFrames": 2,
+                "RepeatPps": "DISABLED"
+              }
+            },
+            "AfdSignaling": "NONE",
+            "DropFrameTimecode": "ENABLED",
+            "RespondToAfd": "NONE",
+            "ColorMetadata": "INSERT"
+          },
+          "OutputSettings": {
+            "HlsSettings": {
+              "AudioGroupId": "program_audio",
+              "AudioRenditionSets": "program_audio",
+              "SegmentModifier": "$dt$",
+              "IFrameOnlyManifest": "EXCLUDE"
+            }
+          },
+          "NameModifier": "_360"
+        },
+        {
+          "ContainerSettings": {
+            "Container": "M3U8",
+            "M3u8Settings": {
+              "AudioFramesPerPes": 4,
+              "PcrControl": "PCR_EVERY_PES_PACKET",
+              "PmtPid": 480,
+              "PrivateMetadataPid": 503,
+              "ProgramNumber": 1,
+              "PatInterval": 0,
+              "PmtInterval": 0,
+              "TimedMetadata": "NONE",
+              "TimedMetadataPid": 502,
+              "VideoPid": 481,
+              "AudioPids": [
+                  482,
+                  483,
+                  484,
+                  485,
+                  486,
+                  487,
+                  488,
+                  489,
+                  490,
+                  491,
+                  492
+              ]
+            }
+          },
+          "VideoDescription": {
+            "Width": 960,
+            "ScalingBehavior": "DEFAULT",
+            "Height": 540,
+            "TimecodeInsertion": "DISABLED",
+            "AntiAlias": "ENABLED",
+            "Sharpness": 50,
+            "CodecSettings": {
+              "Codec": "H_264",
+              "H264Settings": {
+                "InterlaceMode": "PROGRESSIVE",
+                "NumberReferenceFrames": 3,
+                "Syntax": "DEFAULT",
+                "Softness": 0,
+                "GopClosedCadence": 1,
+                "GopSize": 2,
+                "Slices": 1,
+                "GopBReference": "DISABLED",
+                "MaxBitrate": 3500000,
+                "SlowPal": "DISABLED",
+                "SpatialAdaptiveQuantization": "ENABLED",
+                "TemporalAdaptiveQuantization": "ENABLED",
+                "FlickerAdaptiveQuantization": "DISABLED",
+                "EntropyEncoding": "CABAC",
+                "FramerateControl": "INITIALIZE_FROM_SOURCE",
+                "RateControlMode": "QVBR",
+                "CodecProfile": "MAIN",
+                "Telecine": "NONE",
+                "MinIInterval": 0,
+                "AdaptiveQuantization": "HIGH",
+                "CodecLevel": "AUTO",
+                "FieldEncoding": "PAFF",
+                "SceneChangeDetect": "TRANSITION_DETECTION",
+                "QualityTuningLevel": "SINGLE_PASS_HQ",
+                "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+                "UnregisteredSeiTimecode": "DISABLED",
+                "GopSizeUnits": "SECONDS",
+                "ParControl": "INITIALIZE_FROM_SOURCE",
+                "NumberBFramesBetweenReferenceFrames": 2,
+                "RepeatPps": "DISABLED"
+              }
+            },
+            "AfdSignaling": "NONE",
+            "DropFrameTimecode": "ENABLED",
+            "RespondToAfd": "NONE",
+            "ColorMetadata": "INSERT"
+          },
+          "OutputSettings": {
+            "HlsSettings": {
+              "AudioGroupId": "program_audio",
+              "AudioRenditionSets": "program_audio",
+              "SegmentModifier": "$dt$",
+              "IFrameOnlyManifest": "EXCLUDE"
+            }
+          },
+          "NameModifier": "_540"
+        },
+        {
+          "ContainerSettings": {
+            "Container": "M3U8",
+            "M3u8Settings": {
+              "AudioFramesPerPes": 4,
+              "PcrControl": "PCR_EVERY_PES_PACKET",
+              "PmtPid": 480,
+              "PrivateMetadataPid": 503,
+              "ProgramNumber": 1,
+              "PatInterval": 0,
+              "PmtInterval": 0,
+              "TimedMetadata": "NONE",
+              "VideoPid": 481,
+              "AudioPids": [
+                  482,
+                  483,
+                  484,
+                  485,
+                  486,
+                  487,
+                  488,
+                  489,
+                  490,
+                  491,
+                  492
+              ]
+            }
+          },
+          "VideoDescription": {
+            "Width": 1280,
+            "ScalingBehavior": "DEFAULT",
+            "Height": 720,
+            "TimecodeInsertion": "DISABLED",
+            "AntiAlias": "ENABLED",
+            "Sharpness": 50,
+            "CodecSettings": {
+              "Codec": "H_264",
+              "H264Settings": {
+                "InterlaceMode": "PROGRESSIVE",
+                "NumberReferenceFrames": 3,
+                "Syntax": "DEFAULT",
+                "Softness": 0,
+                "GopClosedCadence": 1,
+                "GopSize": 2,
+                "Slices": 1,
+                "GopBReference": "DISABLED",
+                "MaxBitrate": 5000000,
+                "SlowPal": "DISABLED",
+                "SpatialAdaptiveQuantization": "ENABLED",
+                "TemporalAdaptiveQuantization": "ENABLED",
+                "FlickerAdaptiveQuantization": "DISABLED",
+                "EntropyEncoding": "CABAC",
+                "FramerateControl": "INITIALIZE_FROM_SOURCE",
+                "RateControlMode": "QVBR",
+                "CodecProfile": "MAIN",
+                "Telecine": "NONE",
+                "MinIInterval": 0,
+                "AdaptiveQuantization": "HIGH",
+                "CodecLevel": "AUTO",
+                "FieldEncoding": "PAFF",
+                "SceneChangeDetect": "TRANSITION_DETECTION",
+                "QualityTuningLevel": "SINGLE_PASS_HQ",
+                "FramerateConversionAlgorithm": "DUPLICATE_DROP",
+                "UnregisteredSeiTimecode": "DISABLED",
+                "GopSizeUnits": "SECONDS",
+                "ParControl": "INITIALIZE_FROM_SOURCE",
+                "NumberBFramesBetweenReferenceFrames": 2,
+                "RepeatPps": "DISABLED"
+              }
+            },
+            "AfdSignaling": "NONE",
+            "DropFrameTimecode": "ENABLED",
+            "RespondToAfd": "NONE",
+            "ColorMetadata": "INSERT"
+          },
+          "OutputSettings": {
+            "HlsSettings": {
+              "AudioGroupId": "program_audio",
+              "AudioRenditionSets": "program_audio",
+              "SegmentModifier": "$dt$",
+              "IFrameOnlyManifest": "EXCLUDE"
+            }
+          },
+          "NameModifier": "_720"
+        },
+        {
+          "ContainerSettings": {
+            "Container": "M3U8",
+            "M3u8Settings": {}
+          },
+          "AudioDescriptions": [
+            {
+              "AudioSourceName": "Audio Selector 1",
+              "CodecSettings": {
+                "Codec": "AAC",
+                "AacSettings": {
+                  "Bitrate": 96000,
+                  "CodingMode": "CODING_MODE_2_0",
+                  "SampleRate": 48000
+                }
+              }
+            }
+          ],
+          "OutputSettings": {
+            "HlsSettings": {
+              "AudioGroupId": "program_audio",
+              "AudioTrackType": "ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT"
+            }
+          },
+          "NameModifier": "_audio"
+        }
+      ],
+      "OutputGroupSettings": {
+        "Type": "HLS_GROUP_SETTINGS",
+        "HlsGroupSettings": {
+          "ManifestDurationFormat": "INTEGER",
+          "SegmentLength": 6,
+          "TimedMetadataId3Period": 10,
+          "CaptionLanguageSetting": "OMIT",
+          "Destination": "s3://EXAMPLE-BUCKET/HLS/",
+          "DestinationSettings": {
+            "S3Settings": {
+              "AccessControl": {
+                "CannedAcl": "PUBLIC_READ"
+              }
+            }
+          },
+          "TimedMetadataId3Frame": "PRIV",
+          "CodecSpecification": "RFC_4281",
+          "OutputSelection": "MANIFESTS_AND_SEGMENTS",
+          "ProgramDateTimePeriod": 600,
+          "MinSegmentLength": 0,
+          "DirectoryStructure": "SINGLE_DIRECTORY",
+          "ProgramDateTime": "EXCLUDE",
+          "SegmentControl": "SEGMENTED_FILES",
+          "ManifestCompression": "NONE",
+          "ClientCache": "ENABLED",
+          "StreamInfResolution": "INCLUDE"
+        }
+      }
+    }
+  ],
+  "AdAvailOffset": 0,
+  "Inputs": [
+    {
+      "AudioSelectors": {
+        "Audio Selector 1": {
+          "Offset": 0,
+          "DefaultSelection": "DEFAULT",
+          "ProgramSelection": 1
+        }
+      },
+      "VideoSelector": {
+        "ColorSpace": "FOLLOW"
+      },
+      "FilterEnable": "AUTO",
+      "PsiControl": "USE_PSI",
+      "FilterStrength": 0,
+      "DeblockFilter": "DISABLED",
+      "DenoiseFilter": "DISABLED",
+      "TimecodeSource": "EMBEDDED",
+      "FileInput": "s3://EXAMPLE-INPUT-BUCKET/input.mp4"
+    }
+  ]
+}

--- a/aws/lambda/batch_transcode/main.go
+++ b/aws/lambda/batch_transcode/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/mediaconvert"
+)
+
+const jobSettingPath = "job.json"
+
+// Get URI path for a file stored in S3 bucket.
+func s3Path(bucket, key string) string {
+	return fmt.Sprintf("s3://%s/%s", bucket, key)
+}
+
+// Load the configuration of mediaconvert job settings.
+func loadJobSettings() (*mediaconvert.JobSettings, error) {
+	buf, err := os.ReadFile(jobSettingPath)
+	if err != nil {
+		log.Printf("failed to load job setting file: %v", err)
+		return nil, err
+	}
+	var js *mediaconvert.JobSettings
+	if err = json.Unmarshal(buf, &js); err != nil {
+		log.Printf("failed to unmarshal job settings, %v", err)
+		return nil, err
+	}
+	return js, nil
+}
+
+// Invoke the AWS Lambda function to trancode the given video to outputs.
+func handler(ctx context.Context, event events.S3Event) error {
+	bucket := event.Records[0].S3.Bucket.Name
+	key := event.Records[0].S3.Object.Key
+	js, err := loadJobSettings()
+	if err != nil {
+		return err
+	}
+	js.Inputs[0].FileInput = aws.String(s3Path(bucket, key))
+	js.OutputGroups[0].OutputGroupSettings.HlsGroupSettings.Destination = aws.String(s3Path(os.Getenv("AWS_VOD_HLS_BUCKET"), key))
+	// Create a mediaconvert job
+	mc := mediaconvert.New(session.Must(session.NewSession(&aws.Config{
+		Endpoint: aws.String(os.Getenv("AWS_VOD_MEDIACONVERT_URL")),
+	})))
+	out, err := mc.CreateJob(&mediaconvert.CreateJobInput{
+		Role:     aws.String(os.Getenv("AWS_VOD_ROLE_ARN")),
+		Settings: js,
+	})
+	if err != nil {
+		log.Printf("failed to launch mediaconvert job: %v", err)
+		return err
+	}
+	log.Printf("mediaconvert job launched %v", out)
+	return nil
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/molpadia/molpastream
 go 1.18
 
 require (
+	github.com/aws/aws-lambda-go v1.32.1
 	github.com/aws/aws-sdk-go v1.44.32
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0


### PR DESCRIPTION
## Summary
Add a lambda function to transcode the uploaded video file to HLS format. 

### Reference
- https://stackoverflow.com/questions/21197239/decoding-json-using-json-unmarshal-vs-json-newdecoder-decode
- https://github.com/sdn0303/transcoder/tree/93fedfb5d26c991a5bfe241f1efd93908a0a2669
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/tutorial-s3-batchops-lambda-mediaconvert-video.html#batchops-s3-step7
- https://medium.com/@federicopanini/video-content-generated-solution-with-aws-lambda-ccb5d5d4629c
- https://docs.aws.amazon.com/mediaconvert/latest/ug/example-job-settings.html
- https://docs.aws.amazon.com/mediaconvert/latest/apireference/postman-collection-files.html
- https://docs.amazonaws.cn/en_us/mediaconvert/latest/apireference/important-notes.html